### PR TITLE
Mainly to make nicenicks work with emit_print instead of prnt

### DIFF
--- a/python/nicenicks/nicenicks.py
+++ b/python/nicenicks/nicenicks.py
@@ -294,7 +294,7 @@ def message_callback(word, word_eol, userdata):
         newnick = ecs('o') + col(color) + nick
         word[0] = newnick
         hexchat.emit_print(event_name, *word)
-        return hexchat.EAT_HEXCHAT
+        return hexchat.EAT_ALL
     else:
         return hexchat.EAT_NONE
 
@@ -306,8 +306,8 @@ try:
 except:
     pass
 
-hexchat.hook_print("Channel Message", message_callback, "Channel Message")
-hexchat.hook_print("Channel Action", message_callback, "Channel Action")
+hexchat.hook_print("Channel Message", message_callback, "Channel Message", priority=hexchat.PRI_HIGHEST)
+hexchat.hook_print("Channel Action", message_callback, "Channel Action", priority=hexchat.PRI_HIGHEST)
 
 hexchat.hook_command("NICENICKS", nicenicks_command, None, hexchat.PRI_NORM, "NICENICKS INFO:\t\nThis script will colourize nicks of users automatically, using a 'least-recently-used' algorithm (to avoid two people having the same colour).\n\nFriends' nicks can be assigned a specific colour with the SETCOLOR command, a list of colors can be shown with the COLORTABLE command, and this script can be enabled/disabled with the NICENICKS command (/NICENICKS on or /NICENICKS off).\n\nAlso, for fun, try '/NICENICKS_DUMP', or '/NICEDEBUG on'")
 hexchat.hook_command("NICEDEBUG", nicedebug_command, None, hexchat.PRI_NORM, "Usage:\t/NICEDEBUG On to enable, /NICEDEBUG Off to disable.")

--- a/python/nicenicks/nicenicks.py
+++ b/python/nicenicks/nicenicks.py
@@ -22,8 +22,6 @@
 ##     give them the same colours.
 ##   + Could also do this when we see two users' nicks occurring close together very frequently
 ##     over time, making them easier to differentiate in a conversation.
-##   * Channel tables are currently universal in the whole client, not differentiating between
-##     channels of the same name on different servers.
 ##   + Another idea for doing nick colouring is to assign more than one colour to a nick which has
 ##     more than one recognisable part. For example, "JoeBloggs17" could have "Joe",
 ##     "Bloggs", and "17" coloured differently to each other - for more uniqueness.


### PR DESCRIPTION
* Changed things to be Python 3 compatible (but it will still work in Python 2)
* I got rid of the %-code replacement (%C %B etc) because it didn't seem to handle cases where the message to be processed includes such a code beforehand.
   * I did this before I realised I could replace `message_callback` with a `hook_print` (see below). If I did that first, this wouldn't have practically mattered, and I don't really have anything against changing it back.
   * For instance, another client sending the message "Hello %C4 world", "world" would turn out to be coloured after being processed. I don't think that's intended, and it wouldn't appear coloured if the script wasn't there.
   * A practical example I can think of is how many people use mode prefixes as part of names when referring to others. For instance, if I'm half-op in a channel, "Hello %Burrito" would result in "Hello **urrito**".
* I replaced what I removed above with a dictionary which was a bit clunky-looking when put into practice, so I also changed `fprint` to `jprint`, to work just as a function to concatenate strings together. I also made some helper/convenience functions that output strings: `ecs`,  `col`
   * As above, I have nothing against changing this back, either.
* `message_callback` is now a `hook_print` so that it is only triggered by what HexChat already decided is a channel message or action, we don't need to decide that any more.
* Messages from other clients now go through "emit_print" so that they behave exactly as channel messages. All we do now is replace the nick strings with different nick strings which have the needed colour codes on them.
   * This also solves the "identify-msg" capability issue.
* I made it so that `omsg`s and `dmsg`s get an "**(nn)** " tag, might be easier for people with many plugins, and for when going through logs.
* I gave an error message for when file writing fails.
* I changed the asterisk import `from xchat import *` to `import hexchat`, it's easier for people (like me) who use IDEs, code completion, and other analysis tools.
* I made a channel's `colortable` unique to that channel on that network, so that other channels on other networks with the same name don't share a `colortable`.
* The config dir is now in the hexchat configuration directory. **I'm not sure how to make this backwards compatible**, especially considering that some users might have defined "datafile" to be an absolute directory which is not below the current working directory of the script. So users using this new version would need to move their nicenicks.dat file to the hexchat config directory, or change the "datafile" variable to the appropriate filename.

Other than that, things are mostly as they were. Overall behaviour is (I hope) the same according to what I think is the intended outcome. Any features I want to add or change, I'll do that in a repo of my own.

What do you think of these changes, @epitron?