### PR TITLE
It isn't usually correct to cast from a int to a void*.  Be explicit about the bogusness by casting through a uintptr_t.

### DIFF
--- a/c/tcl/tclplugin.c
+++ b/c/tcl/tclplugin.c
@@ -840,7 +840,7 @@ static int tcl_on(ClientData cd, Tcl_Interp * irp, int argc, const char *argv[])
         for (index = 0; index < XC_SIZE; index++) {
             if (strcmp(xc[index].event, token) == 0) {
                 if (xc[index].hook == NULL) {
-                    xc[index].hook = hexchat_hook_print(ph, xc[index].emit, HEXCHAT_PRI_NORM, Print_Hook, (void *) index);
+                    xc[index].hook = hexchat_hook_print(ph, xc[index].emit, HEXCHAT_PRI_NORM, Print_Hook, (void *)(uintptr_t)index);
                     break;
                 }
             }


### PR DESCRIPTION
This fixes the warning described here:

```
tclplugin.c:843:107: warning: cast to 'void *' from smaller integer type 'int' [-Wint-to-void-pointer-cast]
                    xc[index].hook = hexchat_hook_print(ph, xc[index].emit, HEXCHAT_PRI_NORM, Print_Hook, (void *) index);
```